### PR TITLE
Fix GH-1: bump forge to build 93 and fix compatibility issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 minecraft_version=1.14.4
-forge_version=28.0.21
+forge_version=28.0.93
 jei_version=6.0.0.7
 
 version_major=2

--- a/src/main/java/snownee/kiwi/Kiwi.java
+++ b/src/main/java/snownee/kiwi/Kiwi.java
@@ -447,7 +447,7 @@ public class Kiwi
 
     public void init(FMLCommonSetupEvent event)
     {
-        CraftingHelper.register(new ResourceLocation(MODID, "is_loaded"), new ModuleLoadedCondition());
+        CraftingHelper.register(new ModuleLoadedCondition.Serializer());
         CraftingHelper.register(new ResourceLocation(MODID, "full_block"), FullBlockIngredient.SERIALIZER);
 
         KiwiManager.MODULES.values().forEach(m -> m.init(event));

--- a/src/main/java/snownee/kiwi/crafting/ModuleLoadedCondition.java
+++ b/src/main/java/snownee/kiwi/crafting/ModuleLoadedCondition.java
@@ -1,22 +1,49 @@
 package snownee.kiwi.crafting;
 
-import java.util.function.BooleanSupplier;
-
 import com.google.gson.JsonObject;
-
 import net.minecraft.util.JSONUtils;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.crafting.IConditionSerializer;
+import net.minecraftforge.common.crafting.conditions.ICondition;
+import net.minecraftforge.common.crafting.conditions.IConditionSerializer;
 import snownee.kiwi.Kiwi;
 
-public class ModuleLoadedCondition implements IConditionSerializer
+public class ModuleLoadedCondition implements ICondition
 {
+    public static final ResourceLocation ID = new ResourceLocation(Kiwi.MODID, "is_loaded");
+
+    final ResourceLocation module;
+
+    public ModuleLoadedCondition(ResourceLocation module) {
+        this.module = module;
+    }
 
     @Override
-    public BooleanSupplier parse(JsonObject json)
-    {
-        ResourceLocation module = new ResourceLocation(JSONUtils.getString(json, "module"));
-        return () -> Kiwi.isLoaded(module);
+    public ResourceLocation getID() {
+        return ID;
+    }
+
+    @Override
+    public boolean test() {
+        return Kiwi.isLoaded(this.module);
+    }
+
+    public static final class Serializer implements IConditionSerializer<ModuleLoadedCondition> {
+
+        @Override
+        public void write(JsonObject json, ModuleLoadedCondition condition) {
+            json.addProperty("module", condition.module.toString());
+        }
+
+        @Override
+        public ModuleLoadedCondition read(JsonObject json) {
+            ResourceLocation module = new ResourceLocation(JSONUtils.getString(json, "module"));
+            return new ModuleLoadedCondition(module);
+        }
+
+        @Override
+        public ResourceLocation getID() {
+            return ModuleLoadedCondition.ID;
+        }
     }
 
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -10,3 +10,10 @@ description='''Huge thanks to my supporters:
 
 粉鱼 Lioness131 皮蛋 Cherls idyllic_bean 鱼加盐有点咸 洋葱菜菜子 面条公爵 车轮饼 mc00zhu 洛华 纪华裕
 '''
+
+[[dependencies.kiwi]]
+   modId="forge"
+   mandatory=true
+   versionRange="[28.0.93,)"
+   ordering="NONE"
+   side="BOTH"


### PR DESCRIPTION
This change causes Kiwi to require Forge build 93 as minimum in order to run.